### PR TITLE
add: add_context_labels function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -840,3 +840,65 @@ impl Display for Snake {
         self.as_str().fmt(f)
     }
 }
+
+/// Given a sequence of labels (and a LineIndex),
+/// find all input lines that are touched by the labels.
+/// Then add unmarked labels (= output unannoteted lines) for all lines
+/// that are within  the context range, but don't have any label.
+///
+/// The label ranges `r` must fulfill the same conditions as for `[Block::new()]`
+/// The `context` range must be within the byte range covered by `idx`
+
+pub fn add_context_labels<I, T, S>(
+    idx: &LineIndex,
+    labels: I,
+    context: Range<usize>,
+) -> Option<Vec<Label<Range<usize>, T, S>>>
+where
+    I: IntoIterator<Item = Label<Range<usize>, T, S>>,
+    S: Default,
+{
+    let mut labels: Vec<_> = labels.into_iter().collect();
+    let mut prev_range: Option<Range<_>> = None;
+    // verify labels are sorted and non-overlapping
+    for Label { kind, code, style } in &labels {
+        if code.start > code.end {
+            return None;
+        }
+        if let Some(prev) = prev_range.replace(code.clone()) {
+            if code.start <= prev.start || code.start < prev.end {
+                return None;
+            }
+        }
+    }
+    labels.reverse();
+
+    let mut out_labels = Vec::new();
+    let start_line = idx.get(context.start)?.line_no;
+    let end_line = idx.get(context.end)?.line_no;
+    for line_no in start_line..end_line + 1 {
+        // push existing labels before this line.
+        while let Some(last_label) = labels.iter().last() {
+            let label_end_line_no = idx.get(last_label.code.end)?.line_no;
+            if label_end_line_no < line_no {
+                out_labels.push(labels.pop().unwrap());
+            } else {
+                break;
+            }
+        }
+        // is there a label on this line?
+        if let Some(last_label) = labels.iter().last() {
+            let label_start_line_no = idx.get(last_label.code.start)?.line_no;
+            let label_end_line_no = idx.get(last_label.code.end)?.line_no;
+            if label_start_line_no <= line_no && line_no <= label_end_line_no {
+                continue;
+            }
+        }
+        // no? push an unlabeled Label
+        out_labels.push(Label::new(
+            idx.0[line_no].0..idx.0[line_no].0 + idx.0[line_no].1.len(),
+        ));
+    }
+    out_labels.extend(labels.into_iter().rev());
+    Some(out_labels)
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -30,6 +30,30 @@ fn format<const N: usize>(code: &str, labels: [Label<Range<usize>, &str, bool>; 
     )
 }
 
+fn format_with_context<const N: usize>(
+    code: &str,
+    labels: [Label<Range<usize>, &str, bool>; N],
+    context: Range<usize>,
+) -> String {
+    let idx = LineIndex::new(code);
+
+    let mut prev_empty = false;
+    let labels = codesnake::add_context_labels(&idx, labels, context).unwrap();
+    let block = Block::new(&idx, labels).unwrap();
+    let block = block.with_paint(paint).map_code(|s| {
+        let sub = usize::from(core::mem::replace(&mut prev_empty, s.is_empty()));
+        let s = s.replace('\t', "    ");
+        let w = unicode_width::UnicodeWidthStr::width(&*s);
+        CodeWidth::new(s, core::cmp::max(w, 1) - sub)
+    });
+    format!(
+        "\n{}\n{}\n{block}{}\n",
+        block.prologue(),
+        block.space_vert(),
+        block.epilogue()
+    )
+}
+
 fn main() {
     // to find the byte positions in this example
     for ci in SRC.char_indices() {
@@ -495,6 +519,66 @@ fn s1bn1() {
   ┆     ─  
   ┆
 4 │ this is getting silly
+──╯
+"
+    );
+}
+
+#[test]
+fn context_wt() {
+    let should = format_with_context(SRC, [Label::new(70..70).with_text("!")], 4..69);
+    println!("{should}");
+    assert_eq!(
+        should,
+        "
+  ╭─
+  │
+1 │ foo bar
+2 │ baz toto
+3 │ look, a fish 🐟 and a hook 🪝
+4 │ this is getting silly
+  ┆                    ┬ 
+  ┆                    │ 
+  ┆                    ╰── !
+──╯
+"
+    );
+}
+
+#[test]
+fn context_m() {
+    let should = format_with_context(SRC, [Label::new(4..4).with_snake()], 0..15);
+    println!("{should}");
+    assert_eq!(
+        should,
+        "
+  ╭─
+  │
+1 │ foo bar
+  ┆     ─  
+2 │ baz toto
+──╯
+"
+    );
+}
+
+#[test]
+fn context_wt_context() {
+    let should = format_with_context(SRC, [Label::new(15..25).with_text("hello")], 10..72);
+    println!("{should}");
+    assert_eq!(
+        should,
+        "
+  ╭─
+  │
+2 │   baz toto
+  ┆          ▲
+  ┆ ╭────────╯
+3 │ │ look, a fish 🐟 and a hook 🪝
+  ┆ │        ▲                     
+  ┆ │        │                     
+  ┆ ╰────────┴────────────────────── hello
+4 │   this is getting silly
 ──╯
 "
     );


### PR DESCRIPTION
Now that we have 'unlabeled' labeled lines, codesnake can benefit from a helper function around them.

As per your suggestion as separate function, which has the benefit of composing, i.e. one could use it multiple times.