### PR TITLE
Do not use empty labels before EOF in tests

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -49,6 +49,7 @@ fn main() {
     let block = block.with_paint(paint).map_code(|s| {
         let s = s.replace('\t', "    ");
         let w = unicode_width::UnicodeWidthStr::width(&*s);
+        // we are using `max` here to correctly handle EOF
         CodeWidth::new(s, core::cmp::max(w, 1))
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,10 +389,13 @@ impl<'a, T, S: Default + Clone> Block<&'a str, T, S> {
             let mut end = idx.get(code.end)?;
             debug_assert!(start.line_no <= end.line_no);
 
-            // the end of the range is just at the beginning of a new line,
-            // thus make the label end at the end of the previous line,
+            // if the end of the range is just at the beginning of a new line,
+            // then make the range end at the end of the previous line
+            // otherwise, we would produce an empty incoming line part,
+            // which could lead following parts in that line to be shifted
             if end.bytes == 0 && code.start < code.end {
                 end = idx.get(code.end - 1)?;
+                debug_assert!(end.bytes == end.line.len());
             }
 
             let mut parts = match lines.pop() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,7 @@ impl<C, T, S> Label<C, T, S> {
 }
 
 /// Piece of code together with its display width.
+#[derive(Debug)]
 pub struct CodeWidth<C> {
     code: C,
     width: usize,
@@ -299,6 +300,7 @@ impl<F: Fn(&mut Formatter) -> fmt::Result> Display for FromFn<F> {
     }
 }
 
+#[derive(Debug)]
 enum LabelKind<T> {
     None,
     Snake,
@@ -306,11 +308,13 @@ enum LabelKind<T> {
 }
 
 /// Sequence of lines, containing code `C`, (label) text `T`, and style `S`.
+#[derive(Debug)]
 pub struct Block<C, T, S> {
     lines: Vec<Line<C, T, S>>,
     paint: Paint<S>,
 }
 
+#[derive(Debug)]
 struct Line<C, T, S> {
     no: usize,
     parts: LineParts<C, T, S>,
@@ -326,6 +330,7 @@ impl<C, T, S> Line<C, T, S> {
 }
 
 /// Line parts, containing code `C`, (label) text `T`, and style `S`.
+#[derive(Debug)]
 struct LineParts<C, T, S> {
     /// snake that comes from another line, potentially with text
     incoming: Option<(C, Option<T>, S)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,8 +386,14 @@ impl<'a, T, S: Default + Clone> Block<&'a str, T, S> {
                 }
             }
             let start = idx.get(code.start)?;
-            let end = idx.get(code.end)?;
+            let mut end = idx.get(code.end)?;
             debug_assert!(start.line_no <= end.line_no);
+
+            // the end of the range is just at the beginning of a new line,
+            // thus make the label end at the end of the previous line,
+            if end.bytes == 0 && code.start < code.end {
+                end = idx.get(code.end - 1)?;
+            }
 
             let mut parts = match lines.pop() {
                 Some((line_no, _line, parts)) if line_no == start.line_no => parts,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -62,6 +62,28 @@ fn s1() {
 }
 
 #[test]
+fn s1s1_including_newline() {
+    assert_eq!(
+        format(
+            SRC,
+            [
+                Label::new(4..8).with_snake(),
+                Label::new(12..16).with_snake()
+            ]
+        ),
+        "
+  ╭─
+  │
+1 │ foo bar
+  ┆     ───
+2 │ baz toto
+  ┆     ────
+──╯
+"
+    );
+}
+
+#[test]
 fn s1s1() {
     assert_eq!(
         format(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -14,13 +14,11 @@ fn paint(f: &mut Formatter, style: &bool, s: &dyn Display) -> fmt::Result {
 fn format<const N: usize>(code: &str, labels: [Label<Range<usize>, &str, bool>; N]) -> String {
     let idx = LineIndex::new(code);
 
-    let mut prev_empty = false;
     let block = Block::new(&idx, labels).unwrap();
     let block = block.with_paint(paint).map_code(|s| {
-        let sub = usize::from(core::mem::replace(&mut prev_empty, s.is_empty()));
         let s = s.replace('\t', "    ");
         let w = unicode_width::UnicodeWidthStr::width(&*s);
-        CodeWidth::new(s, core::cmp::max(w, 1) - sub)
+        CodeWidth::new(s, core::cmp::max(w, 1))
     });
     format!(
         "\n{}\n{}\n{block}{}\n",
@@ -234,23 +232,6 @@ fn t2t2() {
 }
 
 #[test]
-fn empty() {
-    assert_eq!(
-        format(
-            SRC,
-            [Label::new(2..2).with_snake(), Label::new(4..7).with_snake()]
-        ),
-        "
-  ╭─
-  │
-1 │ foo bar
-  ┆   ─ ───
-──╯
-"
-    );
-}
-
-#[test]
 fn adjacent() {
     assert_eq!(
         format(
@@ -301,7 +282,7 @@ fn n1t1() {
     assert_eq!(
         format(
             SRC,
-            [Label::new(24..24), Label::new(25..25).with_text("hello")]
+            [Label::new(24..25), Label::new(25..26).with_text("hello")]
         ),
         "
   ╭─
@@ -413,9 +394,9 @@ fn n1bt1n1() {
         format(
             SRC,
             [
-                Label::new(4..4),
-                Label::new(25..25).with_text("hello"),
-                Label::new(70..70),
+                Label::new(4..5),
+                Label::new(25..26).with_text("hello"),
+                Label::new(70..71),
             ],
         ),
         "
@@ -435,7 +416,7 @@ fn n1bt1n1() {
 #[test]
 fn n1bn1() {
     assert_eq!(
-        format(SRC, [Label::new(4..4), Label::new(70..70)]),
+        format(SRC, [Label::new(4..5), Label::new(70..71)]),
         "
   ╭─
   │
@@ -449,14 +430,14 @@ fn n1bn1() {
 #[test]
 fn n1bs1() {
     assert_eq!(
-        format(SRC, [Label::new(4..4), Label::new(70..70).with_snake()]),
+        format(SRC, [Label::new(4..5), Label::new(67..72).with_snake()]),
         "
   ╭─
   │
 1 │ foo bar
   ┆
 4 │ this is getting silly
-  ┆                    ─ 
+  ┆                 ─────
 ──╯
 "
     );
@@ -469,7 +450,7 @@ fn n1bs1_style() {
             SRC,
             [
                 Label::new(0..3).with_style(true),
-                Label::new(70..70).with_snake(),
+                Label::new(67..72).with_snake(),
             ],
         ),
         "
@@ -478,7 +459,7 @@ fn n1bs1_style() {
 1 │ <span>foo</span> bar
   ┆
 4 │ this is getting silly
-  ┆                    ─ 
+  ┆                 ─────
 ──╯
 "
     );
@@ -487,7 +468,7 @@ fn n1bs1_style() {
 #[test]
 fn s1bn1() {
     assert_eq!(
-        format(SRC, [Label::new(4..4).with_snake(), Label::new(70..70)],),
+        format(SRC, [Label::new(4..5).with_snake(), Label::new(70..71)],),
         "
   ╭─
   │


### PR DESCRIPTION
To clarify: Empty labels should only be used for EOF, if the `max(w, 1)` trick is used.